### PR TITLE
Improve dwarf 5 ranges support

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -63,7 +63,7 @@ err_handler(Dwarf_Error err, Dwarf_Ptr errarg)
     exit(1);
 }
 
-static int 
+static int
 dwarf5_ranges(Dwarf_Die cu_die,
     Dwarf_Addr *lowest,
     Dwarf_Addr *highest);
@@ -275,6 +275,17 @@ get_pc_range_die(Dwarf_Die die,
 #endif
 
 static int
+get_rnglist_offset(Dwarf_Attribute attr, Dwarf_Unsigned* offset) {
+    Dwarf_Half attrform = 0;
+    dwarf_whatform(attr, &attrform, NULL);
+    if (attrform == DW_FORM_rnglistx) {
+        return dwarf_formudata(attr, offset, NULL);
+    } else {
+        return dwarf_global_formref(attr, offset, NULL);
+    }
+}
+
+static int
 dwarf5_ranges(Dwarf_Die cu_die,
     Dwarf_Addr *lowest,
     Dwarf_Addr *highest)
@@ -289,7 +300,7 @@ dwarf5_ranges(Dwarf_Die cu_die,
     if (res != DW_DLV_OK) {
         return res;
     }
-    if (dwarf_global_formref(attr, &offset, NULL) == DW_DLV_OK) {
+    if (get_rnglist_offset(attr, &offset) == DW_DLV_OK) {
         Dwarf_Unsigned rlesetoffset = 0;
         Dwarf_Unsigned rnglists_count = 0;
         Dwarf_Rnglists_Head head = 0;
@@ -687,8 +698,8 @@ main(int argc, char *argv[])
     Dwarf_Debug dbg;
     char *objfile = "a.out";
     Dwarf_Bool do_read_stdin = FALSE;
-    char buf[MAX_ADDR_LEN]; 
-    char *pc_buf = 0; 
+    char buf[MAX_ADDR_LEN];
+    char *pc_buf = 0;
     char *endptr = 0;
     lookup_tableT lookup_table;
     Dwarf_Ptr errarg = 0;


### PR DESCRIPTION
First of all thank you so much for all your work with libdwarf! On a test executable generated with clang 15 (defaults to dwarf 5) I’ve ran into a bug with the dwarf5_ranges implementation
```
468 DW_DLE_RNGLISTS_ERROR(468) Corrupt dwarf. Bad .debug_rnglists data.
```

It looks like this is a matter of checking if DW_AT_ranges is a DW_FORM_rnglistx.